### PR TITLE
wrong field initial order in JstormAMHandler

### DIFF
--- a/jstorm-on-yarn/src/main/java/com/alibaba/jstorm/yarn/handler/JstormAMHandler.java
+++ b/jstorm-on-yarn/src/main/java/com/alibaba/jstorm/yarn/handler/JstormAMHandler.java
@@ -25,10 +25,10 @@ import java.util.concurrent.BlockingQueue;
 public class JstormAMHandler implements JstormAM.Iface {
 
     public JstormAMHandler(JstormMaster jm) {
-        amRMClient = jstormMasterContext.amRMClient;
-        requestQueue = jstormMasterContext.requestBlockingQueue;
         this.jstormMasterContext = jm.jstormMasterContext;
         this.jstormMaster = jm;
+        amRMClient = jstormMasterContext.amRMClient;
+        requestQueue = jstormMasterContext.requestBlockingQueue;
     }
 
     private static final Log LOG = LogFactory.getLog(JstormAMHandler.class);


### PR DESCRIPTION
JstormAMHandler构造器里字段的初始化顺序错误，会引发NPE